### PR TITLE
Add references support

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,8 +17,8 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
+import os
+import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
 
@@ -28,11 +28,14 @@
 #
 # needs_sphinx = '1.0'
 
+# [UNCOMMENT FOR DEVELOPMENT] sys.path.append(os.path.abspath('../sphinxcontrib'))
+
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
     'sphinxcontrib.pseudocode',
+    # [UNCOMMENT FOR DEVELOPMENT] 'pseudocode',
     'sphinx.ext.autosummary'
 ]
 
@@ -106,5 +109,5 @@ html_show_sourcelink = True
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'sphinxcontrib-pseudocodedoc'
 
-
+numfig = True
 

--- a/docs/demo.rst
+++ b/docs/demo.rst
@@ -1,4 +1,4 @@
-
+.. _hello-world-algo:
 .. pcode::
    :linenos:
 
@@ -6,6 +6,7 @@
     \PRINT \texttt{'hello world'}
     \end{algorithmic}
 
+.. _quick-sort:
 .. pcode::
    :linenos:
 
@@ -77,6 +78,7 @@
     \END{ALGORITHMIC}
     \END{ALGORITHM}
 
+.. _test-control-blocks:
 .. pcode::
 
     \begin{algorithm}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,10 +1,44 @@
+****************************************
 Welcome to Sphinxcontrib-pseudocode demo
-========================================
+****************************************
 
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
 
-Below shows various rendered algorithms, which are copied from corresponding `pseudocode.js examples <https://github.com/SaswatPadhi/pseudocode.js/blob/master/static/body.html.part>`__. The source code of those algorithms can be found `here <https://github.com/xxks-kkk/sphinxcontrib-pseudocode/blob/master/docs/demo.rst>`__.
-             
+########
+Features
+########
+
+Below shows various rendered algorithms, which are copied from corresponding `pseudocode.js examples <https://github.com/SaswatPadhi/pseudocode.js/blob/master/static/body.html.part>`__.
+The source code of those algorithms can be found `here <https://github.com/xxks-kkk/sphinxcontrib-pseudocode/blob/master/docs/demo.rst>`__.
+
+We can also reference any particular algorithm. For example, we can also reference each algorithm:
+
+- ``:numref:`quick-sort``` produces :numref:`quick-sort`
+- ``:numref:`Here is my algorithm {number} <quick-sort>``` produces :numref:`Here is my algorithm {number} <quick-sort>`
+- ``:ref:`test control blocks <test-control-blocks>``` produces :ref:`test control blocks <test-control-blocks>`
+
+By default, each ``pcode`` is mapped to 'Algorithm %s' when referenced via ``numref``. You can change this
+behavior by overriding the corresponding string of ``'pseudocode'`` key in `numfig_format <https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-numfig_format>`_.
+
 .. include:: demo.rst
+
+##########
+Limitation
+##########
+
+- If there are more than :math:`\LaTeX` algorithm block within a ``pcode`` directive::
+
+    \begin{algorithm}
+    \caption{Test atoms}
+    \begin{algorithmic}
+    \STATE my algorithm 1
+    \END{ALGORITHMIC}
+    \END{ALGORITHM}
+
+  The numbering of the algorithm and the numbering when you reference it will out of sync.
+  As an example, ``:numref:`test-control-blocks``` shows :numref:`test-control-blocks` but
+  the algorithm is actually numbered with 5. The reason is that both Algorithm 3 and 4
+  are within the same ``pcode`` directive. If there is only one :math:`\LaTeX` algorithm block
+  for each ``pcode`` directive, there is no problem.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.0
+current_version = 0.5.0
 
 [bdist_wheel]
 universal = 1

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 import io
 from setuptools import setup, find_namespace_packages
 
-version = '0.4.0'
+version = '0.5.0'
 
 # read the contents of your README file
 from pathlib import Path


### PR DESCRIPTION
** Why is this change required? **

We add references support by allowing :numref: to work with
our pcode directive.

The key idea is to follow reference code repository and
mimic how :numref: interacts with figure (just take a look
at one figure HTML code generated from sphinx-doc with
numfig = True).

ref:

- https://github.com/sphinx-contrib/stuffcounter/blob/8f23850da5afe61eeaa37342a6557f443d546a28/sphinxcontrib/stuffcounter/__init__.py#L30

** How does this change solve the issue? **

** Does this commit cause any expected behavior to change?  If so, what? **

** Issue: **

** Design Docs: **